### PR TITLE
Also compare \inhibitglue with \c_empty_tl

### DIFF
--- a/zxjatype.sty
+++ b/zxjatype.sty
@@ -384,6 +384,7 @@
   % by this package.
   { ( \cs_if_free_p:N \inhibitglue )
     || ( \cs_if_eq_p:NN \inhibitglue \scan_stop: )
+    || ( \cs_if_eq_p:NN \inhibitglue \c_empty_tl )
     || ( \cs_if_eq_p:NN \inhibitglue \prg_do_nothing: ) }
   {
     \cs_undefine:N \inhibitglue


### PR DESCRIPTION
Since all `expl3` functions are "`\long`" (not "`nopar`"), in contrast with variables such as `\c_empty_tl`, which are "`nopar`", we are going to change `\prg_do_nothing:` to make it `\long`.  I think `zxjatype` should compare `\inhibitglue` to both an empty macro and an empty long macro.
